### PR TITLE
Add CI workflow to run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ cmake catch2
+      - name: Configure
+        run: cmake -S . -B build -DBUSTACHE_ENABLE_TESTING=ON
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: cd build && ctest --output-on-failure


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that builds and tests the project on pushes and pull requests

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b57b1e68388327938311dac14e0428